### PR TITLE
当登录失败时通过非零退出码终止程序，让workflow执行失败而非正常执行结束，失败触发提醒用户

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import random
 import time
 import functools
+import sys
 
 from loguru import logger
 from playwright.sync_api import sync_playwright
@@ -107,7 +108,8 @@ class LinuxDoBrowser:
 
     def run(self):
         if not self.login():
-            return
+            logger.error("登录失败，程序终止")
+            sys.exit(1)  # 使用非零退出码终止整个程序
         self.click_topic()
         self.print_connect_info()
 


### PR DESCRIPTION
当用户更改掉账号密码而未及时更新Action secrets时，workflow依旧会成功执行，即便是程序已经登录失败了无法自动读帖；此时用户并不会知晓功能已经失效。  PR：校验登录失败时结束run( ) ➡ 修改为终止整个程序，workflow执行失败触发邮件通知用户