### PR TITLE
修复采用LINUXDO_USERNAME和LINUXDO_PASSWORD环境变量时，github CI报错问题

### DIFF
--- a/.github/workflows/daily-check-in.yml
+++ b/.github/workflows/daily-check-in.yml
@@ -28,6 +28,8 @@ jobs:
         env:
           USERNAME: ${{ secrets.USERNAME }}
           PASSWORD: ${{ secrets.PASSWORD }}
+          LINUXDO_USERNAME: ${{ secrets.LINUXDO_USERNAME }}
+          LINUXDO_PASSWORD: ${{ secrets.LINUXDO_PASSWORD }}
           GOTIFY_URL: ${{ secrets.GOTIFY_URL }}
           GOTIFY_TOKEN: ${{ secrets.GOTIFY_TOKEN }}
           SC3_PUSH_KEY: ${{ secrets.SC3_PUSH_KEY }}


### PR DESCRIPTION
#22 
> ![Image](https://github.com/user-attachments/assets/0fabfc6f-209c-489a-8a01-2e42aa853363)
> 
> ![Image](https://github.com/user-attachments/assets/6354d200-429d-4679-b922-71899687e865)
> 
> 我也登录不了

